### PR TITLE
types(all): create typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const perseverant = require('perseverant');
 const storage = perseverant.createInstance('my-project'):Perseverant
 const storage = perseverant.createInstance({
   name,       // by default 'global'
-  folder,     // by default HOME/.perseverant
+  folder,     // by default $HOME/.perseverant
   serializer  // by default JSON
 }):Perseverant
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An asynchronous, persistent, localForage inspired, filesystem based storage solution for NodeJS.",
   "main": "cjs/index.js",
   "module": "esm/index.js",
+  "types": "types.d.ts",
   "scripts": {
     "build": "npm run cjs && npm run esm && npm test",
     "cjs": "cp index.js cjs/ && echo 'module.exports = new Perseverant({});' >> cjs/index.js",

--- a/types.d.ts
+++ b/types.d.ts
@@ -63,7 +63,7 @@ declare class Perseverant {
   /**
    * returns the length of keys
    */
-  length(callback?: () => any): Promise<number>;
+  length(callback?: (length: number) => any): Promise<number>;
 
   /**
    * returns all keys

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ interface IPerseverantOptions<TSerializer = typeof JSON> {
    */
   name?: string;
   /**
-   * Name of storage folder. Default is `'HOME/.perseverant'`
+   * Name of storage folder. Default is `'$HOME/.perseverant'`
    */
   folder?: string;
   /**
@@ -68,7 +68,7 @@ declare class Perseverant {
   /**
    * returns all keys
    */
-  keys<TCallbackReturn>(callback: (files: string[]) => TCallbackReturn): Promise<TCallbackReturn>;
+  keys<TCallbackReturn>(callback: (keys: string[]) => TCallbackReturn): Promise<TCallbackReturn>;
   /**
    * returns all keys
    */

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,78 @@
+interface IPerseverantOptions<TSerializer = typeof JSON> {
+  /**
+   * Name of the storage. Default is `'global'`
+   * Hightly suggested to use non-default name
+   */
+  name?: string;
+  /**
+   * Name of storage folder. Default is `'HOME/.perseverant'`
+   */
+  folder?: string;
+  /**
+   * Serializer / Derserializer. Default is `JSON`
+   */
+  serializer?: TSerializer;
+}
+
+declare class Perseverant {
+
+  /**
+   * 
+   * @param instanceNameOrOptions name or instance options of Perseverant instance. Can be omitted entirely to set default values for everything
+   */
+  createInstance(instanceNameOrOptions?: string | IPerseverantOptions): Perseverant;
+
+  /**
+   * retrieve a key (read key file)
+   */
+  getItem<T, TCallbackReturn>(key: string, callback: (item: T | null) => TCallbackReturn): Promise<TCallbackReturn>;
+  /**
+   * retrieve a key (read key file)
+   */
+  getItem<T = any>(key: string): Promise<T | null>;
+
+  /**
+   * store a key (write key file)
+   */
+  setItem<T, TCallbackReturn>(key: string, value: T, callback: (savedItem: T) => TCallbackReturn): Promise<TCallbackReturn>;
+  /**
+   * store a key (write key file)
+   */
+  setItem<T>(key: string, value: T): Promise<T>;
+
+  /**
+   * remove a key (unlink key file)
+   */
+  removeItem<TCallbackReturn>(key: string, callback: () => TCallbackReturn): Promise<TCallbackReturn>;
+  /**
+   * remove a key (unlink key file)
+   */
+  removeItem(key: string): Promise<void>;
+  
+  /**
+   * clear all keys for the named storage (rm -rf folder and its files)
+   * WARNING: if you call this on global name, it'll clean it all
+   */
+  clear(): Promise<void>;
+  /**
+   * clear all keys for the named storage (rm -rf folder and its files)
+   * WARNING: if you call this on global name, it'll clean it all
+   */
+  clear<T>(callback?: () => T): Promise<T>;
+
+  /**
+   * returns the length of keys
+   */
+  length(callback?: () => any): Promise<number>;
+
+  /**
+   * returns all keys
+   */
+  keys<TCallbackReturn>(callback: (files: string[]) => TCallbackReturn): Promise<TCallbackReturn>;
+  /**
+   * returns all keys
+   */
+  keys(): Promise<string[]>;
+}
+
+export = Perseverant;


### PR DESCRIPTION
The following is used for test typings. Because of difference between esmjs export and commonjs, folks who use path `'perseverant/esm'` needs to turn on option esm module interop

```ts
import * as Perseverant from 'perseverant';

class Item {
  store(): this {
    return this;
  }
}

const storage = Perseverant.createInstance('asd');

storage
  .getItem<string>('name')
  // item should have type string
  .then((item) => {});

// because of item1 declaration is string
// this `.getItem` should have generic types <string, number>
storage
  .getItem(
    'name',
    (item1: string) => Math.random()
  )
  // item2 should have type number (inferred)
  .then(item2 => {});

storage
  .setItem('name', new Item)
  // item should have type Item
  .then(item => {});
storage
  .setItem(
    'name',
    new Item,
    // item should have type Item
    (item) => Math.random()
  )
  // item2 should have type number
  .then((item2) => {});
```